### PR TITLE
给用户增加一个接口，用来指定batch在哪个维度

### DIFF
--- a/syops/flops_counter.py
+++ b/syops/flops_counter.py
@@ -21,7 +21,8 @@ def get_model_complexity_info(model, input_res, dataloader=None,
                               verbose=False, ignore_modules=[],
                               custom_modules_hooks={}, backend='pytorch',
                               syops_units=None, param_units=None,
-                              output_precision=2):
+                              output_precision=2,
+                              batch_dim_idx=0):
     assert type(input_res) is tuple
     assert len(input_res) >= 1
     assert isinstance(model, nn.Module)
@@ -35,7 +36,8 @@ def get_model_complexity_info(model, input_res, dataloader=None,
                                                       custom_modules_hooks,
                                                       output_precision=output_precision,
                                                       syops_units=syops_units,
-                                                      param_units=param_units)
+                                                      param_units=param_units,
+                                                      batch_dim_idx=batch_dim_idx)
     else:
         raise ValueError('Wrong backend name')
 


### PR DESCRIPTION
比较常用的spikingjelly库的默认输入维度为[T,batchsize, c,h,w]，这与当前库的默认输入维度不同，当前库在计算batchsize时默认batch在0号维度上，这可能导致batch计算错误，这次修改增加了一个参数，用来指定batch在哪个维度上，方便后续的代码batch_counter的计数。代码加的不好哈，仅当参考